### PR TITLE
fix: Role that the StackSet creates has backup/ as path but the Backup Policy does not reference it like that.

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -98,7 +98,7 @@ locals {
         tags = {
           backup-policy = {
             iam_role_arn = {
-              "@@assign" = "arn:aws:iam::$account:role/${p.backup_role_name}"
+              "@@assign" = "arn:aws:iam::$account:role/backup/${p.backup_role_name}"
             }
 
             tag_key = {


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

I was very happy to find a sample for a setup with Backup Policies in AWS, as it seemed quite complicated to set up without IaC. When I ran the Terraform Module I found that the policy created by the StackSet creates is always in the `backup/` path.
However the Backup Policy does not reference the IAM Role with that path. This will result in an error when the backup plan is executed.

The fix here just hardcodes the `backup/` path in the Backup Policy, because it is also hardcoded in the StackSet.

## why

<!--
- Provide the justifications for the changes (e.g. business case).
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

<img width="1001" alt="Screenshot 2024-11-01 at 10 01 49" src="https://github.com/user-attachments/assets/46367fe0-1aab-40a0-b480-17f3e9c87cda">

